### PR TITLE
Updated regex to allow hard mode and colorblind settings

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -255,7 +255,7 @@ client.on('messageCreate', (message) => {
     const isAdmin = message.member?.permissions.has("ADMINISTRATOR");
 
     // Check for Wordle Score
-    const wordleRegex = /Wordle \d{3} ([\dX])\/6\n{0,2}[⬛🟩🟨⬜]{5}/;
+    const wordleRegex = /Wordle \d{3} ([\dX])\/6\*?\n{0,2}[⬛🟩🟨⬜🟧🟦]{5}/;
     const wordleMessage = message.content.match(wordleRegex);
 
     if (wordleMessage) {


### PR DESCRIPTION
Changed the regex for matching wordle results to allow for the asterisk that indicates 'hard mode' and the orange and blue square emojis used in the colorblind settings of the game.